### PR TITLE
Use rgba_color!/2 for validating color options

### DIFF
--- a/lib/image/color.ex
+++ b/lib/image/color.ex
@@ -147,6 +147,14 @@ defmodule Image.Color do
     [r, g, b, a]
   end
 
+  def rgba_color!(color, a)
+  when (is_binary(color) or is_atom(color)) and is_integer(a) do
+    a = Integer.mod(a, 256)
+
+    [r, g, b] = Keyword.get(rgb_color!(color), :rgb, color)
+    [r, g, b, a]
+  end
+
   def rgba_color!([r, g, b], a) do
     [r, g, b, a]
   end

--- a/lib/image/options/draw.ex
+++ b/lib/image/options/draw.ex
@@ -129,15 +129,9 @@ defmodule Image.Options.Draw do
   end
 
   defp validate_option(type, {:color, color}, options)
-      when type in [:mask, :point, :circle, :rect, :line, :flood] do
-    case Color.rgb_color(color) do
-      {:ok, color} ->
-        rgb =  if Keyword.keyword?(color), do: Keyword.fetch!(color, :rgb), else: color
-        {:cont, Keyword.put(options, :color, rgb)}
-
-      {:error, reason} ->
-        {:halt, {:error, reason}}
-    end
+    when type in [:mask, :point, :circle, :rect, :line, :flood] do
+      rgba = Color.rgba_color!(color)
+      {:cont, Keyword.put(options, :color, rgba)}
   end
 
   defp validate_option(:flood, {:equal, equal}, options) do

--- a/test/image_draw_test.exs
+++ b/test/image_draw_test.exs
@@ -26,4 +26,19 @@ defmodule Image.Draw.Test do
       Image.write(image, "/Users/kip/Desktop/draw2.png")
   end
 
+  describe "line/6" do
+    test "draws a line on given image" do
+      {:ok, image} = Vix.Vips.Operation.black(5, 5, bands: 1)
+      {:ok, image} = Image.Draw.line(image, 0, 0, 0, 4, color: :white)
+
+      assert {
+        :ok,
+        <<255, 0, 0, 0, 0,
+          255, 0, 0, 0, 0,
+          255, 0, 0, 0, 0,
+          255, 0, 0, 0, 0,
+          255, 0, 0, 0, 0>>
+      } = Vix.Vips.Image.write_to_binary(image)
+    end
+  end
 end


### PR DESCRIPTION
When we want to draw a line on an image we get the error below 👇

```elixir
iex(2)> img = Image.open!("/Users/burak/Downloads/2x2-maze.png")
%Vix.Vips.Image{ref: #Reference<0.3273394107.1287258135.133832>}
iex(4)> Image.Draw.line(img, 0, 3, 1, 3)
** (CaseClauseError) no case clause matching: {:error, "operation build: linear: vector must have 1 or 4 elements"}
    (vix 0.14.0) lib/vix/vips/image.ex:573: Vix.Vips.Image.mutate/2
    (image 0.14.2) lib/image/draw.ex:277: Image.Draw.line/6
    iex:4: (file)
```

That's because Vix only accepts either an rgba vector or a 1x1 vector (not sure what that represents though). So in this PR, we're using `rgba_color!/2` when validating color options.

---

Other problem was that `@opacity` is an integer value however the `rgba_color!/2` was only considering `float` values for alpha value resulting in function clause error.
```elixir
iex(10)> Image.Color.rgba_color!(:black)
** (FunctionClauseError) no function clause matching in Image.Color.rgba_color!/2

    The following arguments were given to Image.Color.rgba_color!/2:

        # 1
        :black

        # 2
        255

    Attempted function clauses (showing 4 out of 4):

        def rgba_color!(color, _a) when color === :none or color === :transparent
        def rgba_color!(color, a) when is_binary(color) and is_integer(a)
        def rgba_color!(color, a) when is_binary(color) or is_atom(color) and is_float(a) and a >= 0.0 and a <= 1.0
        def rgba_color!([r, g, b], a)

    (image 0.14.2) lib/image/color.ex:133: Image.Color.rgba_color!/2
    iex:10: (file)
```

To address this I've additionally taken the mod of the passed integer alpha value but there might be a better solution. I just don't really know what kind of value should exactly be passed as alpha value. Either a value [0.0, 1] or [0, 255]? 